### PR TITLE
Changes gatekeeper to support tasks in staging and starting states.

### DIFF
--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -441,7 +441,7 @@ func (g *Gatekeeper) RequestToken(providerKey string, taskId string, requestedRo
 	}
 	if provider, ok := g.Schedulers[providerKey]; ok {
 		if task, err := provider.LookupTask(taskId); err == nil {
-			if time.Since(task.StartTime()) >= g.config.MaxTaskLife {
+			if !task.StartingState() && time.Since(task.StartTime()) >= g.config.MaxTaskLife {
 				g.metrics.Denied()
 				return "", 0, ErrTaskNotFresh
 			}
@@ -581,7 +581,7 @@ func (g *Gatekeeper) RenewalWorker(controlChan chan struct{}) {
 			if err := g.RenewToken(); err == nil {
 				log.Infof("Renewed Vault Token (original ttl: %v)", ttl)
 			} else {
-				log.Warn("Failed to renew Vault token. Is the policy set correctly? Gatekeeper will now be sealed: %v", err)
+				log.Warnf("Failed to renew Vault token. Is the policy set correctly? Gatekeeper will now be sealed: %v", err)
 				g.Seal()
 				return
 			}

--- a/gatekeeper_test.go
+++ b/gatekeeper_test.go
@@ -348,6 +348,14 @@ func TestRequestToken(t *testing.T) {
 		if _, _, err := g.RequestToken("mock", "expired", "", ""); err != ErrTaskNotFresh {
 			t.Fatalf("Expired task should have returned task not fresh: %v", err)
 		}
+
+		if _, _, err := g.RequestToken("mock", "starting", "", ""); err != nil {
+			t.Fatalf("Token request should have succeeded for starting task: %v", err)
+		}
+
+		if _, _, err := g.RequestToken("mock", "staging", "", ""); err != nil {
+			t.Fatalf("Token request should have succeeded for staging task: %v", err)
+		}
 	} else if err == nil {
 		t.Fatalf("Failed to create gatekeeper instance: could not unseal.")
 	} else {

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -56,6 +56,10 @@ func (t task) StartTime() time.Time {
 	return t.startTime
 }
 
+func (t task) StartingState() bool {
+	return false
+}
+
 func NewECSScheduler() (scheduler.Scheduler, error) {
 	e := &ecsScheduler{
 		Session: session.New(),

--- a/scheduler/mock/mock.go
+++ b/scheduler/mock/mock.go
@@ -14,6 +14,7 @@ type task struct {
 	name      string
 	startTime time.Time
 	ip        net.IP
+	state     string
 }
 
 func (t task) Id() string {
@@ -38,6 +39,10 @@ func (t task) IP() net.IP {
 
 func (t task) StartTime() time.Time {
 	return t.startTime
+}
+
+func (t task) StartingState() bool {
+	return t.state == "starting" || t.state == "staging"
 }
 
 type mockScheduler struct{}
@@ -69,12 +74,27 @@ func (m *mockScheduler) LookupTask(taskId string) (scheduler.Task, error) {
 			startTime: time.Now(),
 		}, nil
 	}
-
 	if taskId == "expired" {
 		return &task{
 			id:        taskId,
 			name:      "mock-task",
 			startTime: time.Now().AddDate(-1, 0, 0),
+		}, nil
+	}
+	if taskId == "starting" {
+		return &task{
+			id:        taskId,
+			name:      "mock-task",
+			startTime: time.Unix(0, 0),
+			state:     "starting",
+		}, nil
+	}
+	if taskId == "staging" {
+		return &task{
+			id:        taskId,
+			name:      "mock-task",
+			startTime: time.Unix(0, 0),
+			state:     "staging",
 		}, nil
 	}
 	return nil, scheduler.ErrTaskNotFound

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -15,6 +15,7 @@ type Task interface {
 	Image() string
 	IP() net.IP
 	StartTime() time.Time
+	StartingState() bool
 }
 
 type Scheduler interface {


### PR DESCRIPTION
### Reason
Gatekeeper does not support validation of tasks in staging or starting states, which means that the mesos hook modules cannot use it. Since these are still valid tasks, the code needs to be changed to support them.
### Implementation
Changes to the go code.
### Verification
Unit tests for the added functionality.
### Testing
Tested it on a vault-mesos-gatekeeper environment with a hook module that sends a request to gatekeeper for a vault token before the tasks starts running.