### PR TITLE
Adds support for Vault namespaces.

### DIFF
--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -40,6 +40,11 @@ const samplePolicy = `{
 	"mesos:framework:service/*": {
 	    "roles":["mesos_framework_service"],
 	    "num_uses":1
+	},
+	"mesos:framework:namespace": {
+	    "roles":["mesos_framework_namespace"],
+		"num_uses":1,
+		"namespace":"test"
 	}
 }`
 
@@ -97,6 +102,21 @@ func TestSamplePolicy(t *testing.T) {
 			}
 		} else {
 			t.Fatalf("Test of '%s' failed. Expected: %v Had: %v", "foo", "mesos:framework:task", policy.Roles)
+		}
+
+		if policy, ok := pols.Get("mesos:framework:namespace"); ok {
+			if policy.Roles[0] != "mesos_framework_namespace" {
+				t.Fatalf("Expected most specific role of '%s'. Had: %v", "mesos:framework:namespace", policy.Roles[0])
+			}
+			if policy.NumUses != 1 {
+				t.Fatalf("Expected number of uses to be 1. Had: %v", policy.NumUses)
+			}
+			if policy.Namespace != "test" {
+
+				t.Fatalf("Expected namespace to be 'test'. Had: %v", policy.Namespace)
+			}
+		} else {
+			t.Fatalf("Test of '%s' failed. Could not find policy.", "mesos:framework:namespace")
 		}
 	} else {
 		t.Fatalf("Failed to parse policy from json: %v", err)

--- a/scheduler/mock/mock.go
+++ b/scheduler/mock/mock.go
@@ -68,6 +68,13 @@ func (m *mockScheduler) LookupTask(taskId string) (scheduler.Task, error) {
 				ip:        net.IPv4(127, 0, 0, 1),
 			}, nil
 		}
+		if taskId == "namespace" {
+			return &task{
+				id:        taskId,
+				name:      "namespace",
+				startTime: time.Now(),
+			}, nil
+		}
 		return &task{
 			id:        taskId,
 			name:      "mock-task",

--- a/vault/unsealer/unsealer.go
+++ b/vault/unsealer/unsealer.go
@@ -153,10 +153,11 @@ func (u UserPassUnsealer) Name() string {
 
 // The AppRole unsealer retrives a token using RoleId and SecretId.
 type AppRoleUnsealer struct {
-	RoleId   string
-	SecretId string
-	Endpoint string
-	Wrap     time.Duration
+	RoleId    string
+	SecretId  string
+	Endpoint  string
+	Wrap      time.Duration
+	Namespace string
 	genericUnsealer
 }
 
@@ -174,7 +175,7 @@ func (u AppRoleUnsealer) Token() (string, error) {
 		}{u.RoleId, u.SecretId},
 		MaxRedirects:    10,
 		RedirectHeaders: true,
-	}
+	}.WithHeader("X-Vault-Namespace", u.Namespace)
 	if u.Wrap > 0 {
 		req.AddHeader("X-Vault-Wrap-TTL", u.Wrap.String())
 	}


### PR DESCRIPTION
### Reason
Gatekeeper does not currently support Vault namespaces.
### Implementation
Changed the policy.go and gatekeeper.go files so that a namespace can be added in the Gatekeeper policies and that namespaces are included in vault requests.
### Testing Completed
Added unit tests for namespace support. All previous unit tests pass.